### PR TITLE
Memory leak due to udp port use

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -22,8 +22,8 @@ int MAX_QUEUE_SIZE;
 int LOGGING_INTERVAL;
 int LOGGING_ENABLED;
 char LOGGING_FILE_NAME[256];
-int CLONE_ENABLED = 0;
-int CLONE_DEST_UDP_PORT = 0;
+int CLONE_ENABLED;
+int CLONE_DEST_UDP_PORT;
 char CLONE_DEST_UDP_IP[50];
 
 unsigned long long int packet_counter = 0;


### PR DESCRIPTION
found that when cloning was enabled, it would memory leak when the udp port was used.  This was due to the fact it was pushing to much data at one time. This was fixed by adding a second udp port to the worker thread.  This allows the worker thread to push data and not step on it's self.